### PR TITLE
Install @webdevstudios/prettier-config-js-coding-standards:~1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,30 @@ In your `package.json`, you can add:
 }
 ```
 
+For prettier support, add to `package.json`:
+
+```js
+"prettier": "@webdevstudios/prettier-config-js-coding-standards"
+```
+
 To modify `package.json` quickly using [`jq`](https://stedolan.github.io/jq/) use:
 
 ```bash
-echo $( jq '.eslintConfig = {"extends": "@webdevstudios/js-coding-standards"}' package.json ) | jq . > package-tmp.json && mv package-tmp.json package.json
+echo $( jq '.eslintConfig = {"extends": "@webdevstudios/js-coding-standards"}' package.json ) | jq . > package-tmp.json && mv package-tmp.json package.json && echo $( jq '.prettier = "@webdevstudios/prettier-config-js-coding-standards"' package.json ) | jq . > package-tmp.json && mv package-tmp.json package.json
+
 ```
+
+## Using Prettier
+
+All you need to do to add auto-formatting support is install your favorite Prettier package in your editor or IDE and make sure you re-run the 
 
 __________
 
 # Changelog
+
+## Unreleased
+
+- JS Coding Standards now comes with [Prettier](http://prettier.io/) support! <sup>[PR](https://github.com/WebDevStudios/js-coding-standards/pull/12), [npmjs.org](https://www.npmjs.com/package/@webdevstudios/prettier-config-js-coding-standards)</sup>
 
 ## 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In your `package.json`, you can add:
 }
 ```
 
-For prettier support, add to `package.json`:
+For [Prettier](http://prettier.io/) support, add to `package.json`:
 
 ```js
 "prettier": "@webdevstudios/prettier-config-js-coding-standards"

--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ echo $( jq '.eslintConfig = {"extends": "@webdevstudios/js-coding-standards"}' p
 
 ```
 
-## Using Prettier
-
-All you need to do to add auto-formatting support is install your favorite Prettier package in your editor or IDE and make sure you re-run the the `jq` command above. It should auto-detect the new Prettier config and auto-format your file.
-
-### A note on pre-existing code
-
-You might be working on code that is older than when prettier was installed, so when you save it will auto-format the _entire_ file which may make your diff's bigger than intended because prettier will correct old code automatically.
-
 __________
 
 # Changelog

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ echo $( jq '.eslintConfig = {"extends": "@webdevstudios/js-coding-standards"}' p
 
 ## Using Prettier
 
-All you need to do to add auto-formatting support is install your favorite Prettier package in your editor or IDE and make sure you re-run the 
+All you need to do to add auto-formatting support is install your favorite Prettier package in your editor or IDE and make sure you re-run the the `jq` command above. It should auto-detect the new Prettier config and auto-format your file.
+
+### A note on pre-existing code
+
+You might be working on code that is older than when prettier was installed, so when you save it will auto-format the _entire_ file which may make your diff's bigger than intended because prettier will correct old code automatically.
 
 __________
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,15 @@
         "eslint": ">=6.8.0"
       }
     },
+    "@webdevstudios/prettier-config-js-coding-standards": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@webdevstudios/prettier-config-js-coding-standards/-/prettier-config-js-coding-standards-1.0.0.tgz",
+      "integrity": "sha512-IXAr3nKCocCxzTyVFNC/PHk+VCLbN+qP0m296oF/ANKCkf3u3oXRQCrkWiEQLYzC3UvffV+peBi5F6XrXez9pA==",
+      "requires": {
+        "@wordpress/prettier-config": "~0.4.0",
+        "prettier": "npm:wp-prettier@~2.0.5"
+      }
+    },
     "@wordpress/eslint-plugin": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-2.3.0.tgz",
@@ -195,6 +204,11 @@
         "eslint-plugin-react-hooks": "^1.6.0",
         "requireindex": "^1.2.0"
       }
+    },
+    "@wordpress/prettier-config": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-0.4.0.tgz",
+      "integrity": "sha512-7c4VeugkCwDkaHSD7ffxoP0VC5c///gCTEAT032OhI5Rik2dPxE3EkNAB2NhotGE8M4dMAg4g5Wj2OWZIn8TFw=="
     },
     "ajv": {
       "version": "6.10.2",
@@ -1133,6 +1147,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.0.5",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+      "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A=="
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     {
       "name": "Aubrey Portwood",
       "email": "code@aubreypwd.com",
-      "url": "http://webdevstudios.com"
+      "url": "http://aubreypwd.com"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/WebDevStudios/js-coding-standards",
   "dependencies": {
     "@webdevstudios/eslint-config-js-coding-standards": "~1.0.3",
+    "@webdevstudios/prettier-config-js-coding-standards": "~1.0.0",
     "eslint": ">=7.4.0 <7.5.x"
   },
   "contributors": [


### PR DESCRIPTION
- Installs [Prettier](http://prettier.io/) support for JS Coding Standards, see https://www.npmjs.com/package/@webdevstudios/prettier-config-js-coding-standards
- Adds `README` details to help you integrate it with your project and editor

|Closes|https://github.com/WebDevStudios/js-coding-standards/issues/2|
|-|-|